### PR TITLE
Updated recipie.jade for typo error.

### DIFF
--- a/Wednesday/Session_13_Jade_Templating/EndProject/views/recipie.jade
+++ b/Wednesday/Session_13_Jade_Templating/EndProject/views/recipie.jade
@@ -4,7 +4,7 @@ block pageTitle
 block pageContent
 
     ul
-    each recipe in recipes.list
+    each recipe in recipies.list
         //create a new well for each recipe model
         .well
             h2 #{recipe.name}


### PR DESCRIPTION
Changed the wrong `recipes` word to the correct `recipies` word. 
Otherwise the render of the receipe.jade will return errror "Cannot read property 'list' of undefined".

``` shell
 5|
    6|     ul
  > 7|     each recipe in recipes.list
    8|         //create a new well for each recipe model
    9|         .well
    10|             h2 #{recipe.name}

Cannot read property 'list' of undefined
```
